### PR TITLE
add missing step in mongo init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ fi
 "${mongo_init_bin}" <<EOF
 use ${MONGO_AUTHSOURCE}
 db.auth("${MONGO_INITDB_ROOT_USERNAME}", "${MONGO_INITDB_ROOT_PASSWORD}")
+db=db.getSiblingDB("${MONGO_DBNAME}")
 db.createUser({
   user: "${MONGO_USER}",
   pwd: "${MONGO_PASS}",

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -77,6 +77,7 @@ app_setup_block: |
   "${mongo_init_bin}" <<EOF
   use ${MONGO_AUTHSOURCE}
   db.auth("${MONGO_INITDB_ROOT_USERNAME}", "${MONGO_INITDB_ROOT_PASSWORD}")
+  db=db.getSiblingDB("${MONGO_DBNAME}")
   db.createUser({
     user: "${MONGO_USER}",
     pwd: "${MONGO_PASS}",


### PR DESCRIPTION

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
fixes a documentation bug: if this is not run, mongo user is not created correctly, and docker-unifi-network-application container will repeatedly log "Authentication failed" and "UserNotFound: Could not find user \"unifi\" for db \"unifi\""}} messages. without this fix, application container will not come up without manually creating the mongodb user

## Benefits of this PR and context:
if this is not run, mongo user is not created correctly, and docker-unifi-network-application container will repeatedly log "Authentication failed" and "UserNotFound: Could not find user \"unifi\" for db \"unifi\""}} messages. without this fix, application container will not come up without manually creating the mongodb user

## How Has This Been Tested?
yes, tested locally several times


